### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Hello_world.yml
+++ b/.github/workflows/Hello_world.yml
@@ -1,5 +1,8 @@
 name: Use Docker Login Action
 
+permissions:
+  contents: read
+
 on:
   # push:
   #   branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Maxwell134/Hello_world/security/code-scanning/1](https://github.com/Maxwell134/Hello_world/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define it at the workflow root (top-level), since there is a single job and no special per-job needs are shown.

For `.github/workflows/Hello_world.yml`, insert:

```yml
permissions:
  contents: read
```

directly below `name:` and before `on:`.  
No imports, methods, or dependencies are needed. This preserves existing behavior while satisfying CodeQL and documenting intended token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->