### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sample.yaml
+++ b/.github/workflows/sample.yaml
@@ -2,6 +2,8 @@ name: Run Python Script with Permissions Fixed
 
 on:
  workflow_dispatch
+permissions:
+  contents: read
 jobs:
   run-python:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/Maxwell134/Hello_world/security/code-scanning/16](https://github.com/Maxwell134/Hello_world/security/code-scanning/16)

Add an explicit `permissions` block to the workflow (or job) to enforce least privilege for `GITHUB_TOKEN`.  
Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`), with `contents: read` as the minimal required permission for `actions/checkout`.

In `.github/workflows/sample.yaml`, insert:

```yaml
permissions:
  contents: read
```

This keeps existing functionality unchanged while satisfying CodeQL and least-privilege guidance. No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security posture of workflow configuration with updated access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->